### PR TITLE
serialize tokens for json_encode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.idea
 /vendor

--- a/spec/JwtTokenSpec.php
+++ b/spec/JwtTokenSpec.php
@@ -2,12 +2,14 @@
 
 namespace spec\GenTux\Jwt;
 
-use GenTux\Jwt\JwtPayloadInterface;
 use Prophecy\Argument;
 use GenTux\Jwt\JwtToken;
 use PhpSpec\ObjectBehavior;
+use GenTux\Jwt\JwtPayloadInterface;
+use GenTux\Jwt\Drivers\FirebaseDriver;
 use GenTux\Jwt\Drivers\JwtDriverInterface;
 use GenTux\Jwt\Exceptions\NoTokenException;
+use PhpSpec\Exception\Example\FailureException;
 use GenTux\Jwt\Exceptions\InvalidTokenException;
 
 class JwtTokenSpec extends ObjectBehavior
@@ -106,5 +108,19 @@ class JwtTokenSpec extends ObjectBehavior
         $this->payload('foo')->shouldReturn('bar');
         $this->payload('context')->shouldReturn(['some' => 'data']);
         $this->payload('context.some')->shouldReturn('data');
+    }
+
+    public function it_encodes_to_json_as_a_string_representation_of_the_token(JwtDriverInterface $jwt)
+    {
+        $driver = new FirebaseDriver();
+        $jwt = new JwtToken($driver);
+        $token = $jwt->createToken(['exp' => time() + 100], 'secret');
+
+        $serialized = json_encode(['token' => $token]);
+        $decoded = json_decode($serialized);
+
+        if( ! is_string($decoded->token) || strlen($decoded->token) < 1) {
+            throw new FailureException('Token was not json encoded.');
+        }
     }
 }

--- a/src/JwtToken.php
+++ b/src/JwtToken.php
@@ -2,13 +2,14 @@
 
 namespace GenTux\Jwt;
 
+use JsonSerializable;
 use Illuminate\Support\Arr;
 use GenTux\Jwt\Drivers\JwtDriverInterface;
 use GenTux\Jwt\Exceptions\NoTokenException;
 use GenTux\Jwt\Exceptions\NoSecretException;
 use GenTux\Jwt\Exceptions\InvalidTokenException;
 
-class JwtToken
+class JwtToken implements JsonSerializable
 {
 
     /** @var JwtDriverInterface */
@@ -235,6 +236,20 @@ class JwtToken
 
         return $token;
     }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->token();
+    }
+
 
     /**
      * Convert into string


### PR DESCRIPTION
Bug fix for when `JwtToken` objects are encoded to json with `json_encode`. Currently the `JwtToken` object serializes into an empty stdObj.

The expected behavior should be serializing into the string representation of the JWT token.
